### PR TITLE
fix typo in Adarsh-jaiss's Journey

### DIFF
--- a/journeys/Adarsh-jaiss.md
+++ b/journeys/Adarsh-jaiss.md
@@ -32,7 +32,7 @@ Other than that ,
 
 ▶️ Spending time with my family👪
 
-▶️ Making other pepole's laugh😄
+▶️ Making other people's laugh😄
 
 # Connect with me 
 


### PR DESCRIPTION
# Description

Instead of "people" it is currently "pepole"

