### PR TITLE
Move Gitpod to Navbar instead of after text.

### DIFF
--- a/_layouts/navbar.md
+++ b/_layouts/navbar.md
@@ -1,2 +1,3 @@
 <a href = "https://discord.gg/PGadh3Vyuv"><img src = "https://img.icons8.com/color/344/discord-logo.png" style ="height:4%; width:4%;"></a>
 <a href = "https://twitter.com/collab__"><img src = "https://img.icons8.com/fluency/344/twitter.png" style ="height:4%; width:4%;"></a>
+<a href = "https://gitpod.io/#github.com/collab-community/journey-book"><img src = "https://avatars.githubusercontent.com/u/37021919?s=200&v=4" style = "height:4%; width:4%;"></a>

--- a/index.md
+++ b/index.md
@@ -2,8 +2,6 @@
 
 You've come to the fun part! Tap ANY name below to see their coding journey and get inspired!!
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#github.com/collab-community/journey-book)
-
 <ul id="user-list">
   <li class="user-card" v-for="user in users" :key="user.username">
     <a :href="'#/journeys/' + user.username">


### PR DESCRIPTION
## Description

Instead of the Open In Gitpod being after the text ("You've come to the fun part! Tap ANY name below to see their coding journey and get inspired!!") I added the Gitpod icon to the navbar, what do you think of this @collab-community/journey-book ?
